### PR TITLE
fix: mobile view of the tables on admin page

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -204,16 +204,24 @@
     background: #d7d4d4 !important;
 }
 
+table thead tr td {
+    text-align: left;
+}
+
 .blog-post {
     font-size: 1.1em;
     border-radius: 10px;
     /* margin: 10px; */
     padding: 15px 10px;
-    background: rgb(233, 233, 233);
+    background: #fefefe;
     display: flex;
     align-items: center;
     justify-content: space-evenly;
     margin-bottom: 15px;
+}
+
+.blog-post .fa-trash {
+    color: #FF4040;
 }
 
 .blog-post div {
@@ -254,9 +262,36 @@
     margin: 1em auto;
 }
 
-.add-post-hr {
-    margin-bottom: 1em;
+.post-btn {
+    padding: 0.5em;
+    background: #4E44D3;
+    outline: none;
+    border: none;
+    border-radius: 5px;
+    color: white;
 }
+
+
+#editor input, #editor textarea {
+    border: 1px solid lightgrey;
+    padding: 2px;
+    outline: none;
+}
+
+#editor input:focus, #editor textarea:focus{
+    box-shadow: 0 0 3px #4E44D3;
+}
+
+
+#messages tr td:nth-child(5) {
+    color: #FF4040;
+} 
+
+#users tr td:nth-child(4) {
+    color: #FF4040;
+}
+
+
 
 #successful-update {
     border-radius: 5px;
@@ -314,6 +349,57 @@ td {
 }
 
 /* End of editor box  */
+
+
+@media (max-width: 824px) {
+    .mobile-view-table thead {
+        display: none;
+    }
+
+    .mobile-view-table tr {
+        text-align: left;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: space-evenly;
+        padding-bottom: 1em;
+        border-bottom: 1px solid darkgrey;
+        margin-bottom: 1em;
+    }
+
+    .mobile-view-table tr td:first-child {
+        font-size: 1em;
+        font-weight: bold;
+    }
+
+    #messages tr td:nth-child(3) {
+        letter-spacing: 1px;
+        font-style: italic;
+    }
+
+    #messages tr td:nth-child(4) {
+        opacity: 0.7;
+    }   
+
+
+    #messages tr td:nth-child(5) {
+        color: #FF4040;
+    } 
+
+    #users tr td:nth-child(3) {
+        opacity: 0.7;
+    }
+
+    #users tr td:nth-child(4) {
+        color: #FF4040;
+    }
+}
+
+@media (max-width: 995px) {
+    .title-image-fields {
+        flex-direction: column;
+    }
+}
 
 @media (max-width: 595px) {
     #status {

--- a/pages/admin.html
+++ b/pages/admin.html
@@ -65,7 +65,7 @@
 
                 <div id="blog-posts" class="tab-panel"></div>
                 <div style="text-align: left;" class="tab-panel">
-                    <table>
+                    <table class="mobile-view-table">
                         <thead>
                             <tr>
                                 <th>Name</th>
@@ -86,13 +86,12 @@
                             <div>Title</div><div><input type="text" name="title" id="title" required></div>
                             <div>Image</div><div><input type="file" name="image" id="image" required></div>
                         </div>
-                        <hr class="add-post-hr">
-                        <div>Body</div><div><textarea rows="30" type="text" name="paragraphs" id="paragraphs" required></textarea></div>
-                        <div><button>Post</button></div>
+                        <div>Body</div><div><textarea style="height: 70vh;" type="text" name="paragraphs" id="paragraphs" required></textarea></div>
+                        <div><button class="post-btn">Post</button></div>
                     </form>
                 </div>
                 <div style="text-align: left;" id="user-manager" class="tab-panel">
-                    <table>
+                    <table class="mobile-view-table">
                         <thead>
                             <tr>
                                 <th>Username</th>

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -63,11 +63,13 @@ const updatePost = event => {
                 <div>
                     <div id="successful-update">Post updated successfully</div>
                     <form id="postUpdater" method="POST" action="#" onsubmit="(event) => noRefresh(event)">
-                        <div>Title</div><div><input type="text" name="title" id="title_update" value="${title}"></div>
-                        <div>Author</div><div><input type="text" name="author" id="author_update" value="${author}"></div>
-                        <div>Body</div><div><textarea class="new-body-textarea" rows="27" type="text" name="paragraphs" id="paragraphs_update">${paragraphs}</textarea></div>
-                        <div>New image</div><div><input type="file" name="image" id="image_update" /></div>
-                        <div><button>Update Post</button></div>
+                        <div class="title-image-fields">
+                            <div>Title</div><div><input type="text" name="title" id="title_update" value="${title}"></div>
+                            <div>Author</div><div><input type="text" name="author" id="author_update" value="${author}"></div>
+                            <div>New image</div><div><input type="file" name="image" id="image_update" /></div>
+                        </div>
+                        <div>Body</div><div><textarea class="new-body-textarea" style="height: 70vh" type="text" name="paragraphs" id="paragraphs_update">${paragraphs}</textarea></div>
+                        <div><button class="post-btn">Update Post</button></div>
                     </form>
                 </div>
             `;
@@ -191,7 +193,7 @@ const getPosts = () => {
                     <div class='blog-post displayMod' data-identifier="${doc.id}">
                         <div class="post-title">${doc.data().title}</div>
                         <div class="post-body">${doc.data().paragraphs.toString().split(' ').splice(0, 5).join(" ")}...</div>
-                        <div><i id="a_${doc.id}" class="fa fa-trash fa-lg fa-danger"></i></div>
+                        <div><i id="a_${doc.id}" class="fa fa-trash fa-lg"></i></div>
                         <div><i id="a_${doc.id}-${doc.id}" class="fa fa-pencil fa-lg"></i></div>
                     </div>`;
                 blogPostsWrapper.appendChild(div);


### PR DESCRIPTION
### What this PR does
Add responsive mobile view of the messages and users tables on the admin page

### Task to be completed
Modified admin.css

Modified admin.js

Modified admin.html

### Manual testing
clone github repository then execute index.html then turn on mobile view in the browser
will give you admin credentials to be able to view the admin page

### Background context
N/A

### Relevant pivotal tracker stories
https://trello.com/c/WrXlNVek/89-frontend-fix-issues-with-the-mobile-view-of-the-tables-on-admin-page

### Screenshots
![mv tables](https://user-images.githubusercontent.com/54126307/92020263-2a408d80-ed58-11ea-85e1-1652d08b7868.png)
